### PR TITLE
Update Gradle Wrapper from 9.6.0 to 9.6.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=87a2216cc1f9122192d4e0fe905ffdf1b4c72cff797e9f733b174e157cadd396
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-all.zip
+distributionSha256Sum=61ba77b3ff7167e60962763eb4bae79db7120c189b9544358d0ade3c1e712a83
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-all.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Update Gradle Wrapper from 9.6.0 to 9.6.1.

Read the release notes: https://docs.gradle.org/9.6.1/release-notes.html

---

The checksums of the Wrapper JAR and the distribution binary have been successfully verified.

- Gradle release: `9.6.1`
- Distribution (-all) zip checksum: `61ba77b3ff7167e60962763eb4bae79db7120c189b9544358d0ade3c1e712a83`
- Wrapper JAR Checksum: `497c8c2a7e5031f6aa847f88104aa80a93532ec32ee17bdb8d1d2f67a194a9c7`

You can find the reference checksum values at https://gradle.org/release-checksums/

---

🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.

<details>
<summary>Need help? 🤔</summary>
<br />

If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
</details>